### PR TITLE
Functional DamageArea3D

### DIFF
--- a/addons/nodot/interaction/DamageArea3D.gd
+++ b/addons/nodot/interaction/DamageArea3D.gd
@@ -1,0 +1,27 @@
+## An area that, when entered, deals damage (or heals) the colliding body
+class_name DamageArea3D extends Area3D
+
+## Damage to deal (negative numbers for healing)
+@export var damage: float = 1.0
+## The interval to deal the damage
+@export var damage_interval: float = 1.0
+
+## Triggered when a body is damaged (or healed) by the area
+signal damage_given
+
+func _init():
+  var timer: Timer = Timer.new()
+  timer.autostart = true
+  timer.wait_time = damage_interval
+  timer.connect("timeout", action)
+  add_child(timer)
+  
+## Deals damage to all overlapping bodies
+func action():
+  var colliders = get_overlapping_bodies()
+  if colliders.size() > 0:
+    for collider in colliders:
+      for child in collider.get_children():
+        if child is Health:
+          child.add_health(-damage)
+          emit_signal("damage_given")

--- a/examples/fps/map.tscn
+++ b/examples/fps/map.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=37 format=3 uid="uid://yf3jwue0vvs0"]
+[gd_scene load_steps=40 format=3 uid="uid://yf3jwue0vvs0"]
 
 [ext_resource type="PackedScene" uid="uid://cvr3xfnhuhxn3" path="res://examples/fps/player.tscn" id="1_ry0a0"]
 [ext_resource type="PackedScene" uid="uid://dqsar57406ve3" path="res://examples/fps/objects/military_target.tscn" id="2_x7gfq"]
@@ -15,6 +15,7 @@
 [ext_resource type="AudioStream" uid="uid://bddljpngewaim" path="res://examples/fps/sfx/splash2.mp3" id="11_o4gop"]
 [ext_resource type="AudioStream" uid="uid://cmtc7ntebm7y7" path="res://examples/fps/sfx/splash3.mp3" id="12_laggk"]
 [ext_resource type="ArrayMesh" uid="uid://djcsawrhutin1" path="res://examples/fps/models/steps.obj" id="15_x2811"]
+[ext_resource type="Script" path="res://addons/nodot/interaction/DamageArea3D.gd" id="16_w6uk5"]
 [ext_resource type="PackedScene" uid="uid://d6i6tqipdhuh" path="res://examples/3dplatformer/models/door.tscn" id="16_yvdok"]
 
 [sub_resource type="BoxMesh" id="BoxMesh_0aav7"]
@@ -55,6 +56,12 @@ size = Vector3(10, 5, 1)
 
 [sub_resource type="ConcavePolygonShape3D" id="ConcavePolygonShape3D_uhgr4"]
 data = PackedVector3Array(-5, 2.5, 0.5, 5, 2.5, 0.5, -5, -2.5, 0.5, 5, 2.5, 0.5, 5, -2.5, 0.5, -5, -2.5, 0.5, 5, 2.5, -0.5, -5, 2.5, -0.5, 5, -2.5, -0.5, -5, 2.5, -0.5, -5, -2.5, -0.5, 5, -2.5, -0.5, 5, 2.5, 0.5, 5, 2.5, -0.5, 5, -2.5, 0.5, 5, 2.5, -0.5, 5, -2.5, -0.5, 5, -2.5, 0.5, -5, 2.5, -0.5, -5, 2.5, 0.5, -5, -2.5, -0.5, -5, 2.5, 0.5, -5, -2.5, 0.5, -5, -2.5, -0.5, 5, 2.5, 0.5, -5, 2.5, 0.5, 5, 2.5, -0.5, -5, 2.5, 0.5, -5, 2.5, -0.5, 5, 2.5, -0.5, -5, -2.5, 0.5, 5, -2.5, 0.5, -5, -2.5, -0.5, 5, -2.5, 0.5, 5, -2.5, -0.5, -5, -2.5, -0.5)
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_raloq"]
+size = Vector3(4, 4, 4)
+
+[sub_resource type="FogMaterial" id="FogMaterial_bal54"]
+albedo = Color(1, 0, 0, 1)
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_yk2u5"]
 size = Vector3(23, 4, 11.696)
@@ -144,7 +151,7 @@ skeleton = NodePath("../..")
 shape = SubResource("ConcavePolygonShape3D_78y36")
 
 [node name="StaticBody3D3" type="StaticBody3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.53738, 8)
+transform = Transform3D(-0.686618, 0, 0.727018, 0, 1, 0, -0.727018, 0, -0.686618, 11.9403, 2.53738, -18.9298)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="StaticBody3D3"]
 mesh = SubResource("BoxMesh_wc1fv")
@@ -152,6 +159,18 @@ skeleton = NodePath("../..")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="StaticBody3D3"]
 shape = SubResource("ConcavePolygonShape3D_uhgr4")
+
+[node name="DamageArea3D" type="Area3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9.44011, 2.27853, -16.2815)
+script = ExtResource("16_w6uk5")
+damage = 10.0
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="DamageArea3D"]
+shape = SubResource("BoxShape3D_raloq")
+
+[node name="FogVolume" type="FogVolume" parent="DamageArea3D"]
+size = Vector3(4, 4, 4)
+material = SubResource("FogMaterial_bal54")
 
 [node name="WaterArea3D" type="Area3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -29.2375, -2.01535, 7.25362)
@@ -209,42 +228,44 @@ mesh = SubResource("BoxMesh_mllw1")
 [node name="CollisionShape3D" type="CollisionShape3D" parent="RigidBody3D"]
 shape = SubResource("ConvexPolygonShape3D_h8o56")
 
-[node name="Breakable_Barrel" parent="." instance=ExtResource("3_mk7d7")]
+[node name="Breakables" type="Node3D" parent="."]
+
+[node name="Breakable_Barrel" parent="Breakables" instance=ExtResource("3_mk7d7")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.255405, -7.51625)
 
-[node name="Breakable_Jar" parent="." instance=ExtResource("4_g2uxp")]
+[node name="Breakable_Jar" parent="Breakables" instance=ExtResource("4_g2uxp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.40389, 1.41497, -7.36922)
 
-[node name="Breakable_Jar2" parent="." instance=ExtResource("4_g2uxp")]
+[node name="Breakable_Jar2" parent="Breakables" instance=ExtResource("4_g2uxp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.8742, 0.587597, -6.57374)
 
-[node name="Breakable_Jar3" parent="." instance=ExtResource("4_g2uxp")]
+[node name="Breakable_Jar3" parent="Breakables" instance=ExtResource("4_g2uxp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.62077, 0.587597, -8.42955)
 
-[node name="Breakable_Jar4" parent="." instance=ExtResource("4_g2uxp")]
+[node name="Breakable_Jar4" parent="Breakables" instance=ExtResource("4_g2uxp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.96097, 0.587597, -8.29359)
 
-[node name="Breakable_Jar5" parent="." instance=ExtResource("4_g2uxp")]
+[node name="Breakable_Jar5" parent="Breakables" instance=ExtResource("4_g2uxp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.9634, 0.587597, -7.46282)
 
-[node name="Breakable_Jar6" parent="." instance=ExtResource("4_g2uxp")]
+[node name="Breakable_Jar6" parent="Breakables" instance=ExtResource("4_g2uxp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.94384, 0.587597, -6.54195)
 
-[node name="Breakable_Jar8" parent="." instance=ExtResource("4_g2uxp")]
+[node name="Breakable_Jar8" parent="Breakables" instance=ExtResource("4_g2uxp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -33.6176, 4.46391, 9.24944)
 
-[node name="Breakable_Jar9" parent="." instance=ExtResource("4_g2uxp")]
+[node name="Breakable_Jar9" parent="Breakables" instance=ExtResource("4_g2uxp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.89154, 1.19333, -6.56513)
 
-[node name="Breakable_Crates" parent="." instance=ExtResource("4_nrhjp")]
+[node name="Breakable_Crates" parent="Breakables" instance=ExtResource("4_nrhjp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.63489, 0.603516, -7.51394)
 explosion_force = 1.0
 
-[node name="Breakable_Crates2" parent="." instance=ExtResource("4_nrhjp")]
+[node name="Breakable_Crates2" parent="Breakables" instance=ExtResource("4_nrhjp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.60584, 0.603516, -7.53931)
 explosion_force = 1.0
 
-[node name="Breakable_Crates3" parent="." instance=ExtResource("4_nrhjp")]
+[node name="Breakable_Crates3" parent="Breakables" instance=ExtResource("4_nrhjp")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.58101, 1.43173, -7.5138)
 explosion_force = 1.0
 


### PR DESCRIPTION
Extends an Area3D. Any body that overlaps and has a health node will take damage.

Closes #23